### PR TITLE
Drill 3178

### DIFF
--- a/avatica-server/pom.xml
+++ b/avatica-server/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-avatica-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Avatica Server</name>
   <description>JDBC server.</description>
 

--- a/avatica/pom.xml
+++ b/avatica/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-avatica</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Avatica</name>
   <description>JDBC driver framework.</description>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Core</name>
   <description>Core Calcite APIs and engine.</description>
 

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1760,9 +1760,6 @@ public class SqlToRelConverter {
       Util.permAssert(bb.window == null, "already in window agg mode");
       bb.window = window;
       RexNode rexAgg = exprConverter.convertCall(bb, aggCall);
-      rexAgg =
-          rexBuilder.ensureType(
-              validator.getValidatedNodeType(call), rexAgg, false);
 
       // Walk over the tree and apply 'over' to all agg functions. This is
       // necessary because the returned expression is not necessarily a call

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-example-csv</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Example CSV</name>
   <description>An example Calcite provider that reads CSV files</description>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,13 +20,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-example</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Examples</name>
   <description>Calcite examples</description>
 

--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-linq4j</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Linq4j</name>
   <description>Calcite APIs for LINQ (Language-Integrated Query) in Java</description>
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite MongoDB</name>
   <description>MongoDB adapter for Calcite</description>
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-plus</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Plus</name>
   <description>Miscellaneous extras for Calcite</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <groupId>org.apache.calcite</groupId>
   <artifactId>calcite</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
 
   <!-- More project information. -->
   <name>Calcite</name>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-spark</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Spark</name>
 
   <properties>

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <artifactId>calcite-splunk</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.0-drill-r9</version>
+  <version>1.1.0-drill-r10</version>
   <name>Calcite Splunk</name>
   <description>Splunk adapter for Calcite; also a JDBC driver for Splunk</description>
 

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.1.0-drill-r9</version>
+    <version>1.1.0-drill-r10</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
Don't invoke ensureType() after rewriting the aggregate expression part of the window function. Reason for disabling this is the inherent difference between Calcite and Drill data types. For eg: 

Per Calcite Avg(Int) => Int 
Per Drill     Avg(Int)  => Double 

Because of such difference ensureType will inject a cast to Int at the end of the expression causing wrong results. This is a bigger problem and needs a bigger discussion involving Calcite and Drill data types.
