### PR TITLE
MD-4312: [Part-2]  Push Project past Correlate(LateralJoin)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
@@ -265,19 +265,7 @@ public class PushProjector {
       rightBitmap =
           ImmutableBitSet.range(nFields + nSysFields, nChildFields);
 
-      // Required columns need to be included in project
-      // But when the rowType contains dynamic star, the required column is already included
-      boolean containDynamicStar = false;
-      for (RelDataTypeField field : corrRel.getRowType().getFieldList()) {
-        if (field.isDynamicStar()) {
-          containDynamicStar = true;
-          break;
-        }
-      }
-
-      if (!containDynamicStar) {
-        projRefs.or(BitSets.of(corrRel.getRequiredColumns()));
-      }
+      projRefs.or(BitSets.of(corrRel.getRequiredColumns().asList()));
 
       switch (corrRel.getJoinType()) {
       case INNER:


### PR DESCRIPTION
Modified PushProjector to include correlated columns on the left
side of correlated join, for all cases no matter if it is a star
or a projection with specified columns.

@amansinha100  Please review this PR.